### PR TITLE
GH-5: Normalized `git-exec` path.

### DIFF
--- a/src/find-git-exec.ts
+++ b/src/find-git-exec.ts
@@ -43,7 +43,7 @@ async function findGit(path: string): Promise<Git> {
             resolve({
                 path,
                 version: parseVersion(await exec(path, '--version')),
-                execPath: await exec(path, '--exec-path')
+                execPath: normalizePath(await exec(path, '--exec-path'))
             });
         } catch (error) {
             reject(error);
@@ -120,6 +120,9 @@ function parseVersion(raw: string): string {
     return raw.replace(/^git version /, '');
 }
 
+function normalizePath(pathToNormalize: string): string {
+    return path.normalize(pathToNormalize);
+}
 function env(key: string): string {
     return process.env[key] || '';
 }

--- a/src/find-git-exec.ts
+++ b/src/find-git-exec.ts
@@ -123,6 +123,7 @@ function parseVersion(raw: string): string {
 function normalizePath(pathToNormalize: string): string {
     return path.normalize(pathToNormalize);
 }
+
 function env(key: string): string {
     return process.env[key] || '';
 }


### PR DESCRIPTION
When running on Windows (from GitBash) the exec-path ended up with mixed
UNIX and Windows file separators.

Closes #5.
Task #5.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>