### PR TITLE
use child_process.execFile instead of child.spawn

### DIFF
--- a/src/find-git-exec.spec.ts
+++ b/src/find-git-exec.spec.ts
@@ -5,16 +5,27 @@
 
 import * as fs from 'fs';
 import { expect } from 'chai';
-import findGit from './find-git-exec';
+import findGit, { Git } from './find-git-exec';
 
 describe('find-git-exec', async () => {
 
-    it('find', async () => {
+    it('find', async function () {
+        this.timeout(60_000);
         const git = await findGit({ hint: undefined, onLookup: (p: string) => console.log(`[TRACE]: Git discovery: ${p}`) });
         const { path, version, execPath } = git;
         expect(fs.existsSync(path), `[path]: expected ${path} to exist on the filesystem`).to.be.true;
         expect(fs.existsSync(execPath), `[execPath]: expected ${execPath} to exist on the filesystem`).to.be.true;
         expect(version.startsWith('2'), `[version]: expected version 2.x was ${version} instead`).to.be.true;
+        const promises: Array<Promise<Git>> = [];
+        for (let i = 0; i < 1000; i++) {
+            promises.push(findGit({ hint: undefined, onLookup: (p: string) => {/* silent */ } }));
+        }
+        const results = await Promise.all(promises);
+        results.forEach(({ version: actualVersion, path: actualPath, execPath: actualExecPath }) => {
+            expect(actualVersion).to.be.deep.equal(version, `Expected ${version} as 'version', got ${actualPath} instead.`);
+            expect(actualPath).to.be.deep.equal(path, `Expected ${path} as 'path', got ${actualPath} instead.`);
+            expect(actualExecPath).to.be.deep.equal(execPath, `Expected ${path} as 'execPath', got ${actualPath} instead.`);
+        })
     });
 
 });


### PR DESCRIPTION
in order to overcome an issue with missing (or broken) pipes for parent-child-IPC which is observed when there are more than 511 child processes spawned.

Signed-off-by: Alex Tugarev <alex.tugarev@typefox.io>