### PR TITLE
Allow node 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "find-git-exec",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A lightweight library for locating the Git executable on the host system",
   "keywords": [
     "git"
   ],
   "engines": {
-    "node": ">=10.11.0 <12"
+    "node": ">=10.11.0 <13"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
There's this PR https://github.com/TypeFox/find-git-exec/pull/16 but seems stalled. This PR allows package to run with node 12 for the purposes mentioned in https://github.com/TypeFox/find-git-exec/issues/15